### PR TITLE
Improves model regex, removes restart conditions

### DIFF
--- a/parser_templates/cli/show_version.yaml
+++ b/parser_templates/cli/show_version.yaml
@@ -12,7 +12,7 @@
 
 - name: match model
   pattern_match:
-    regex: "[Cc]isco (.+) \\("
+    regex: "[Cc]isco (\\S+) .* with .+ bytes of memory.$"
   register: model
 
 - name: match hostname
@@ -24,11 +24,6 @@
   pattern_match:
     regex: "^System image file is (\\S+)"
   register: image
-
-- name: match restart conditions
-  pattern_match:
-    regex: "^System restarted at (?P<time>\\d+:\\d+:\\d+) (?P<tz>\\S+)"
-  register: restart_conditions
 
 - name: match reload reason
   pattern_match:
@@ -81,10 +76,6 @@
         value: "{{ image.matches.0 }}"
       - key: model
         value: "{{ model.matches.0 }}"
-      - key: restart_time
-        value: "{{ restart_conditions.time }}"
-      - key: restart_tz
-        value: "{{ restart_conditions.tz }}"
       - key: reload_reason
         value: "{{ reload_reason.matches.0 | lower }}"
       - key: uptime

--- a/tests/parser_templates/cli/show_version/16.6.4.txt
+++ b/tests/parser_templates/cli/show_version/16.6.4.txt
@@ -64,19 +64,18 @@ Technology Package License Information:
 -----------------------------------------------------------------
 Technology    Technology-package           Technology-package
               Current       Type           Next reboot
-              ------------------------------------------------------------------
-              appxk9           appxk9           Permanent        appxk9
-              uck9             None             None             None
-              securityk9       securityk9       Permanent        securityk9
-              ipbase           ipbasek9         Permanent        ipbasek9
+------------------------------------------------------------------
+appxk9           appxk9           Permanent        appxk9
+uck9             None             None             None
+securityk9       securityk9       Permanent        securityk9
+ipbase           ipbasek9         Permanent        ipbasek9
 
-              cisco ISR4431/K9 (1RU) processor with 7939999K/6147K bytes of memory.
-              Processor board ID FGL12345678
-              4 Gigabit Ethernet interfaces
-              32768K bytes of non-volatile configuration memory.
-              16777216K bytes of physical memory.
-              14888959K bytes of flash memory at bootflash:.
-              0K bytes of WebUI ODM Files at webui:.
+cisco ISR4431/K9 (1RU) processor with 7939999K/6147K bytes of memory.
+Processor board ID FGL12345678
+4 Gigabit Ethernet interfaces
+32768K bytes of non-volatile configuration memory.
+16777216K bytes of physical memory.
+14888959K bytes of flash memory at bootflash:.
+0K bytes of WebUI ODM Files at webui:.
 
-              Configuration register is 0x2102
-
+Configuration register is 0x2102

--- a/tests/parser_templates/cli/show_version/main.yaml
+++ b/tests/parser_templates/cli/show_version/main.yaml
@@ -1,4 +1,22 @@
 ---
+### IOS 15.1(4)M4
+- name: 15.1(4)M4 - parse `show version`
+  command_parser:
+    file: "{{ playbook_dir }}/../parser_templates/cli/show_version.yaml"
+    content: "{{ lookup('file', '{{ playbook_dir }}/parser_templates/cli/show_version/15.1.4.txt') }}"
+
+- name: 15.1.4.txt - test `show version` parser
+  assert:
+    that:
+      - system.uptime == '9 weeks, 5 days, 17 hours, 53 minutes'
+      - system.uptime_split.years | int == 0
+      - system.uptime_split.weeks | int == 9
+      - system.uptime_split.days | int == 5
+      - system.uptime_split.hours | int == 17
+      - system.uptime_split.minutes | int == 53
+      - system.version == '15.1(4)M4'
+      - system.model == 'CISCO2921/K9'
+      - system.reload_reason == 'reload'
 
 ### IOS-XE 15.5.1
 
@@ -17,10 +35,8 @@
       - system.uptime_split.hours | int == 23
       - system.uptime_split.minutes | int == 27
       - system.version == '15.5(1)S'
-      - system.model is not none
+      - system.model == 'ISR4431/K9'
       - system.reload_reason == 'reload'
-      - system.restart_time == '09:58:28'
-      - system.restart_tz == 'UTC'
 
 ### IOS-XE 16.6.4
 
@@ -39,31 +55,8 @@
       - system.uptime_split.hours | int == 2
       - system.uptime_split.minutes | int == 23
       - system.version == '16.6.4'
-      - system.model is not none
+      - system.model == 'ISR4431/K9'
       - system.reload_reason == 'poweron'
-      - system.restart_time == '08:29:02'
-      - system.restart_tz == 'UTC'
-
-### IOS 15.1(4)M4
-- name: 15.1(4)M4 - parse `show version`
-  command_parser:
-    file: "{{ playbook_dir }}/../parser_templates/cli/show_version.yaml"
-    content: "{{ lookup('file', '{{ playbook_dir }}/parser_templates/cli/show_version/15.1.4.txt') }}"
-
-- name: 15.1.4.txt - test `show version` parser
-  assert:
-    that:
-      - system.uptime == '9 weeks, 5 days, 17 hours, 53 minutes'
-      - system.uptime_split.years | int == 0
-      - system.uptime_split.weeks | int == 9
-      - system.uptime_split.days | int == 5
-      - system.uptime_split.hours | int == 17
-      - system.uptime_split.minutes | int == 53
-      - system.version == '15.1(4)M4'
-      - system.model is not none
-      - system.reload_reason == 'reload'
-      - system.restart_time == '18:49:38'
-      - system.restart_tz == 'UTC'
 
 ### Done
 


### PR DESCRIPTION
system.restart_time and system.restart_tz cause parser to hang if there is no restart line in show version
model regex was matching the incorrect line for certain IOS or IOS-XE models and versions

Signed-off-by: Luke Russell <lukedrussell+git@outlook.com>